### PR TITLE
fix: public access to event and signed url lock modes

### DIFF
--- a/src/public/sesamy-global-functions.php
+++ b/src/public/sesamy-global-functions.php
@@ -78,7 +78,7 @@ function sesamy_content_container( $atts = null, $content = null ) {
 	);
 
 	// If the article isn't locked, then add the "public" attribute to the container.
-	if ( ! Sesamy_Post_Properties::is_locked( $post_id ) ) {
+	if ( ! Sesamy_Post_Properties::is_locked( $post_id ) || $access_level == 'public') {
 		$atts['public'] = 'true';
 	}
 
@@ -86,6 +86,13 @@ function sesamy_content_container( $atts = null, $content = null ) {
 
 	// Exclude attributes used by WordPress when making sesamy tag.
 	$non_display_atts = array( 'preview' );
+
+	// Only the 'entitlement' access level is supported to use with the 'signedUrl' and 'event' lock modes.
+	// If the access level is not 'entitlement', we change the lock mode to 'embed', so that the content unlocks correctly.
+	if ( ( 'signedUrl' === $atts['lock_mode'] || 'event' === $atts['lock_mode'] ) && $access_level != 'entitlement' ) {
+		$atts['lock_mode'] = 'embed';
+	}
+
 	$html_attributes  = array_filter(
 		$atts,
 		function ( $key ) use ( $non_display_atts ) {


### PR DESCRIPTION
Currently the lock modes `event` and `signedUrl` don't support `public` and `logged-in` access levels, since we don't need to pull the content from an external URL in those cases (if it's public the content should always be visible and if it's logged-in then once the user is logged in the content should be public), treating them as `embed` lock mode will unlock the content correctly.