### PR TITLE
fix: paywall wizard fixes

### DIFF
--- a/src/admin/class-sesamy-settings-admin.php
+++ b/src/admin/class-sesamy-settings-admin.php
@@ -142,6 +142,78 @@ class Sesamy_Settings_Admin {
 				'label_for' => 'sesamy_content_types',
 			)
 		);
+
+		add_settings_field(
+			'sesamy_paywall_wizard',
+			__( 'Use paywall wizard as default', 'sesamy' ),
+			array( $this, 'settings_render_boolean' ),
+			'sesamy',
+			'sesamy_section_general',
+			array(
+				'name'      => 'sesamy_paywall_wizard',
+				'label_for' => 'sesamy_paywall_wizard',
+			)
+		);
+
+		add_settings_field(
+			'sesamy_paywall_wizard_logo_url',
+			__( 'Paywall Wizard Logo URL', 'sesamy' ),
+			array( $this, 'settings_render_input' ),
+			'sesamy',
+			'sesamy_section_general',
+			array(
+				'name'      => 'sesamy_paywall_wizard_logo_url',
+				'label_for' => 'sesamy_paywall_wizard_logo_url',
+			)
+		);
+
+		add_settings_field(
+			'sesamy_paywall_wizard_logo_url',
+			__( 'Paywall Wizard Logo URL', 'sesamy' ),
+			array( $this, 'settings_render_input' ),
+			'sesamy',
+			'sesamy_section_general',
+			array(
+				'name'      => 'sesamy_paywall_wizard_logo_url',
+				'label_for' => 'sesamy_paywall_wizard_logo_url',
+			)
+		);
+
+		add_settings_field(
+			'sesamy_paywall_wizard_title',
+			__( 'Paywall Wizard Title', 'sesamy' ),
+			array( $this, 'settings_render_input' ),
+			'sesamy',
+			'sesamy_section_general',
+			array(
+				'name'      => 'sesamy_paywall_wizard_title',
+				'label_for' => 'sesamy_paywall_wizard_title',
+			)
+		);
+
+		add_settings_field(
+			'sesamy_paywall_wizard_perks',
+			__( 'Paywall Wizard Perks (One per line)', 'sesamy' ),
+			array( $this, 'settings_render_textarea' ),
+			'sesamy',
+			'sesamy_section_general',
+			array(
+				'name'      => 'sesamy_paywall_wizard_perks',
+				'label_for' => 'sesamy_paywall_wizard_perks',
+			)
+		);
+
+		add_settings_field(
+			'sesamy_paywall_wizard_description',
+			__( 'Paywall Wizard Single Purchase Description', 'sesamy' ),
+			array( $this, 'settings_render_textarea' ),
+			'sesamy',
+			'sesamy_section_general',
+			array(
+				'name'      => 'sesamy_paywall_wizard_description',
+				'label_for' => 'sesamy_paywall_wizard_description',
+			)
+		);
 	}
 
 	/**
@@ -230,6 +302,36 @@ class Sesamy_Settings_Admin {
 			$settings_value = get_option( $args['name'] );
 
 			echo '<input type="text" name="' . esc_attr( $args['name'] ) . '" value="' . esc_attr( $settings_value ) . '">';
+		}
+	}
+
+	/**
+	 * Boolean field render
+	 * 
+	 * @param array $args Arguments of boolean fields.
+	 * @since 2.1.2
+	 * @package    Sesamy
+	 */
+	public function settings_render_boolean( $args ) {
+		if ( ! empty( $args ) ) {
+			$settings_value = get_option( $args['name'] );
+
+			echo '<input type="checkbox" name="' . esc_attr( $args['name'] ) . '" value="1" ' . checked( 1, $settings_value, false ) . '>';
+		}
+	}
+
+	/**
+	 * Textarea field render
+	 *
+	 * @param array $args Arguments of textarea fields.
+	 * @since 1.0.0
+	 * @package    Sesamy
+	 */
+	public function settings_render_textarea( $args ) {
+		if ( ! empty( $args ) ) {
+			$settings_value = get_option( $args['name'] );
+
+			echo '<textarea name="' . esc_attr( $args['name'] ) . '">' . esc_attr( $settings_value ) . '</textarea>';
 		}
 	}
 }

--- a/src/admin/gutenberg/sesamy-post-editor/src/sesamyPostEditor.js
+++ b/src/admin/gutenberg/sesamy-post-editor/src/sesamyPostEditor.js
@@ -365,20 +365,22 @@ const SesamyPostEditor = () => {
 					/>
 
 					<TextareaControl
-						label={__("Description", "sesamy")}
-						value={meta["_sesamy_paywall_wizard_description"]}
-						onChange={(value) => {
-							setMeta({ _sesamy_paywall_wizard_description: value });
-						}}
-					/>
-
-					<TextareaControl
 						label={__("Perks (One per line)", "sesamy")}
 						value={meta["_sesamy_paywall_wizard_perks"]}
 						onChange={(value) => {
 							setMeta({ _sesamy_paywall_wizard_perks: value });
 						}}
 					/>
+
+					{meta["_sesamy_enable_single_purchase"] && (
+						<TextareaControl
+							label={__("Single Purchase Description", "sesamy")}
+							value={meta["_sesamy_paywall_wizard_description"]}
+							onChange={(value) => {
+								setMeta({ _sesamy_paywall_wizard_description: value });
+							}}
+						/>
+					)}
 				</>
 			)}
 		</PluginDocumentSettingPanel>

--- a/src/includes/class-sesamy-post-properties.php
+++ b/src/includes/class-sesamy-post-properties.php
@@ -128,7 +128,7 @@ class Sesamy_Post_Properties {
 						'show_in_rest'  => true,
 						'single'        => true,
 						'type'          => 'boolean',
-						'default'       => false,
+						'default'       => true,
 						'auth_callback' => '__return_true',
 					)
 				);

--- a/src/includes/class-sesamy-post-properties.php
+++ b/src/includes/class-sesamy-post-properties.php
@@ -140,7 +140,7 @@ class Sesamy_Post_Properties {
 						'show_in_rest'  => true,
 						'single'        => true,
 						'type'          => 'boolean',
-						'default'       => false,
+						'default'       => get_option( 'sesamy_paywall_wizard' ),
 						'auth_callback' => '__return_true',
 					)
 				);
@@ -153,6 +153,7 @@ class Sesamy_Post_Properties {
 						'single'        => true,
 						'type'          => 'string',
 						'auth_callback' => '__return_true',
+						'default'       => get_option( 'sesamy_paywall_wizard_logo_url' ),
 					)
 				);
 
@@ -164,17 +165,7 @@ class Sesamy_Post_Properties {
 						'single'        => true,
 						'type'          => 'string',
 						'auth_callback' => '__return_true',
-					)
-				);
-
-				register_post_meta(
-					$post_type,
-					'_sesamy_paywall_wizard_description',
-					array(
-						'show_in_rest'  => true,
-						'single'        => true,
-						'type'          => 'string',
-						'auth_callback' => '__return_true',
+						'default'       => get_option( 'sesamy_paywall_wizard_title' ),
 					)
 				);
 
@@ -186,6 +177,19 @@ class Sesamy_Post_Properties {
 						'single'        => true,
 						'type'          => 'string',
 						'auth_callback' => '__return_true',
+						'default'       => get_option( 'sesamy_paywall_wizard_perks' ),
+					)
+				);
+
+				register_post_meta(
+					$post_type,
+					'_sesamy_paywall_wizard_description',
+					array(
+						'show_in_rest'  => true,
+						'single'        => true,
+						'type'          => 'string',
+						'auth_callback' => '__return_true',
+						'default'       => get_option( 'sesamy_paywall_wizard_description' ),
 					)
 				);
 

--- a/src/includes/class-sesamy-settings.php
+++ b/src/includes/class-sesamy-settings.php
@@ -29,6 +29,11 @@ class Sesamy_Settings {
 		register_setting( 'sesamy', 'sesamy_content_types' );
 		register_setting( 'sesamy', 'sesamy_tags' );
 		register_setting( 'sesamy', 'sesamy_client_id' );
+		register_setting( 'sesamy', 'sesamy_paywall_wizard' );
+		register_setting( 'sesamy', 'sesamy_paywall_wizard_logo_url' );
+		register_setting( 'sesamy', 'sesamy_paywall_wizard_title' );
+		register_setting( 'sesamy', 'sesamy_paywall_wizard_description' );
+		register_setting( 'sesamy', 'sesamy_paywall_wizard_perks' );
 	}
 
 	/**

--- a/src/public/class-sesamy-content-container.php
+++ b/src/public/class-sesamy-content-container.php
@@ -209,7 +209,7 @@ class Sesamy_Content_Container {
 					"singlePurchase": {
 						"type": "single",
 						"text": "<?php echo $post->post_title ?>",
-						"description": ""
+						"description": "<?php echo $post_settings['paywall_wizard_description']; ?>"
 					},
 					<?php } ?>
 					<?php

--- a/src/public/class-sesamy-content-container.php
+++ b/src/public/class-sesamy-content-container.php
@@ -289,6 +289,9 @@ class Sesamy_Content_Container {
 				gap: 1rem;
 				justify-content: center;
 			}
+			sesamy-paywall-wizard {
+				width: 100%;
+			}
 		</style>
 		<?php
 


### PR DESCRIPTION
- Fixed width in the second step of the paywall wizard.
- Fixed show login switch true by default.
- Fixed single purchase description appearing below the single purchase button in paywall wizard.
- Added the paywall wizard default settings to the global sesamy settings ("use by default", "logo url", "title", "perks", "single purchase description").